### PR TITLE
Automatic update of Newtonsoft.Json to 13.0.1

### DIFF
--- a/Shop/Shop.Api.Core/Shop.Api.Core.csproj
+++ b/Shop/Shop.Api.Core/Shop.Api.Core.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
       <PackageReference Include="AutoMapper" Version="10.1.1" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Shop/Shop.Api.Data/Shop.Api.Data.csproj
+++ b/Shop/Shop.Api.Data/Shop.Api.Data.csproj
@@ -6,7 +6,7 @@
 
     <ItemGroup>
       <PackageReference Include="MongoDB.Bson" Version="2.11.3" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a major update of `Newtonsoft.Json` to `13.0.1` from `12.0.2`
`Newtonsoft.Json 13.0.1` was published at `2021-03-22T20:10:49Z`, 1 year and 1 month ago

2 project updates:
Updated `Shop.Api.Core\Shop.Api.Core.csproj` to `Newtonsoft.Json` `13.0.1` from `12.0.2`
Updated `Shop.Api.Data\Shop.Api.Data.csproj` to `Newtonsoft.Json` `13.0.1` from `12.0.2`

[Newtonsoft.Json 13.0.1 on NuGet.org](https://www.nuget.org/packages/Newtonsoft.Json/13.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
