### PR TITLE
Automatic update of xunit to 2.4.1

### DIFF
--- a/Shop/Shop.UnitTests/Shop.UnitTests.csproj
+++ b/Shop/Shop.UnitTests/Shop.UnitTests.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
         <PackageReference Include="coverlet.collector" Version="1.0.1" />
     </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `xunit` to `2.4.1` from `2.4.0`
`xunit 2.4.1` was published at `2018-10-29T04:18:23Z`, 3 years and 6 months ago

1 project update:
Updated `Shop.UnitTests\Shop.UnitTests.csproj` to `xunit` `2.4.1` from `2.4.0`

[xunit 2.4.1 on NuGet.org](https://www.nuget.org/packages/xunit/2.4.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
