### PR TITLE
Automatic update of xunit.runner.visualstudio to 2.4.3

### DIFF
--- a/Shop/Shop.UnitTests/Shop.UnitTests.csproj
+++ b/Shop/Shop.UnitTests/Shop.UnitTests.csproj
@@ -11,7 +11,10 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
         <PackageReference Include="xunit" Version="2.4.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <PackageReference Include="coverlet.collector" Version="1.0.1" />
     </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a patch update of `xunit.runner.visualstudio` to `2.4.3` from `2.4.0`
`xunit.runner.visualstudio 2.4.3` was published at `2020-08-03T14:08:03Z`, 1 year and 8 months ago

1 project update:
Updated `Shop.UnitTests\Shop.UnitTests.csproj` to `xunit.runner.visualstudio` `2.4.3` from `2.4.0`

[xunit.runner.visualstudio 2.4.3 on NuGet.org](https://www.nuget.org/packages/xunit.runner.visualstudio/2.4.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
